### PR TITLE
Support XDG_CONFIG_HOME for config file location

### DIFF
--- a/cmd/dependabot-bouncer/main.go
+++ b/cmd/dependabot-bouncer/main.go
@@ -25,7 +25,7 @@ or command-line flags.`,
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $XDG_CONFIG_HOME/dependabot-bouncer/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default search: $XDG_CONFIG_HOME/dependabot-bouncer/config.yaml, or $HOME/.config/dependabot-bouncer/config.yaml if XDG_CONFIG_HOME is unset, then $HOME/.dependabot-bouncer/config.yaml)")
 	rootCmd.PersistentFlags().StringSlice("deny-packages", []string{}, "Packages to deny")
 	rootCmd.PersistentFlags().StringSlice("deny-orgs", []string{}, "Organizations to deny")
 

--- a/cmd/dependabot-bouncer/main.go
+++ b/cmd/dependabot-bouncer/main.go
@@ -25,7 +25,7 @@ or command-line flags.`,
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.dependabot-bouncer/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $XDG_CONFIG_HOME/dependabot-bouncer/config.yaml)")
 	rootCmd.PersistentFlags().StringSlice("deny-packages", []string{}, "Packages to deny")
 	rootCmd.PersistentFlags().StringSlice("deny-orgs", []string{}, "Organizations to deny")
 
@@ -47,7 +47,14 @@ func initConfig() {
 			os.Exit(1)
 		}
 
-		// Search for config in home directory
+		// XDG config directory ($XDG_CONFIG_HOME or ~/.config)
+		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+		if xdgConfigHome == "" {
+			xdgConfigHome = filepath.Join(home, ".config")
+		}
+
+		// Search XDG path first, then legacy home directory path
+		viper.AddConfigPath(filepath.Join(xdgConfigHome, "dependabot-bouncer"))
 		viper.AddConfigPath(filepath.Join(home, ".dependabot-bouncer"))
 		viper.SetConfigType("yaml")
 		viper.SetConfigName("config")


### PR DESCRIPTION
## Summary
- Search `$XDG_CONFIG_HOME/dependabot-bouncer/config.yaml` (defaulting to `~/.config/dependabot-bouncer/`) before the legacy `~/.dependabot-bouncer/` path
- Follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
- Legacy path still works as a fallback

## Test plan
- [ ] Place config at `~/.config/dependabot-bouncer/config.yaml` and verify it is picked up
- [ ] Set `XDG_CONFIG_HOME` to a custom directory, place config there, and verify it is used
- [ ] Verify `~/.dependabot-bouncer/config.yaml` still works when no XDG config exists
- [ ] Verify `--config` flag overrides both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)